### PR TITLE
fix: Add annual-to-monthly frequency fallback for uncached IMF queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name = "cucopy"
 description = "Module for exchanging monetary values and inflation adjustment."
-version = "1.2.4"
-authors = [      
-    {name = "Julian Schönau"},
-    {name = "Jan Göpfert"},
-    {name = "Maxime Gorres"},
-    {name = "Patrick Kuckertz"},
-    {name = "Jann Weinand"},
-    {name = "Leander Kotzur"},
-    {name = "Detlef Stolten"},
+version = "1.2.5"
+authors = [
+    { name = "Julian Schönau" },
+    { name = "Jan Göpfert" },
+    { name = "Maxime Gorres" },
+    { name = "Patrick Kuckertz" },
+    { name = "Jann Weinand" },
+    { name = "Leander Kotzur" },
+    { name = "Detlef Stolten" },
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
-license = {text = "MIT"}
+license = { text = "MIT" }
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -28,24 +28,19 @@ classifiers = [
 keywords = [
     "currency conversion",
     "inflation",
-    "exchange rate",    
+    "exchange rate",
     "monetary",
-    "money",    
+    "money",
     "finance",
 ]
 
-dependencies = [
-    "PyYAML>=6.0",
-    "sdmx1>=2.23.1",
-    "joblib>=1.3.2",
-    "datadesclib"
-]
+dependencies = ["PyYAML>=6.0", "sdmx1>=2.23.1", "joblib>=1.3.2", "datadesclib"]
 
 [project.optional-dependencies]
 test = ["pytest"]
 
 [tool.setuptools]
-package-dir = {"" = "src"}
+package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ keywords = [
 dependencies = [
     "PyYAML>=6.0",
     "sdmx1>=2.23.1",
-    "joblib>=1.3.2"
+    "joblib>=1.3.2",
+    "datadesclib"
 ]
 
 [project.optional-dependencies]

--- a/src/cucopy/currency.py
+++ b/src/cucopy/currency.py
@@ -35,7 +35,7 @@ class Currency(object):
     }
 
     @meta(description="Initialize a Currency instance with a Parser.")
-    def __init____init__(
+    def __init__(
         self,
         ignore_cache: Annotated[bool, {
             "description": "Whether to ignore cached data when fetching CPI and exchange rates",

--- a/src/cucopy/utils.py
+++ b/src/cucopy/utils.py
@@ -87,22 +87,31 @@ def get_single_imf_datapoint(
     if ignore_cache:
         # If current year is requested or cache should be ignored, always get fresh data.
         # We ignore the cache for current year, as the data is updated during the year.
-        return get_imf_value_uncached(
-            indicator=dataset_id, date=year, iso=iso, frequency=frequency
-        )
+        try:
+            return get_imf_value_uncached(
+                indicator=dataset_id, date=year, iso=iso, frequency=frequency
+            )
+        except ValueError:
+            if frequency != 'M':
+                print(f"Warning: No {frequency} data for year {year}. Using monthly frequency instead.")
+                return get_imf_value_uncached(
+                    indicator=dataset_id, date=year, iso=iso, frequency='M'
+                )
+            raise
     else:
         try:
             return get_imf_value_cached(
                 indicator=dataset_id, date=year, iso=iso, frequency=frequency
             )
         except ValueError:
-            # If annual data is not available, fall back to monthly data.
-            # We ignore the cache here as well, as annual data can be available in the future
-            print(f"Warning: No annual data for year {year}. Using monthly frequency instead.")
-            frequency = 'M'
-            return get_imf_value_uncached(
-                indicator=dataset_id, date=year, iso=iso, frequency=frequency
-            )
+            if frequency != 'M':
+                # If annual data is not available, fall back to monthly data.
+                # We ignore the cache here as well, as annual data can be available in the future
+                print(f"Warning: No {frequency} data for year {year}. Using monthly frequency instead.")
+                return get_imf_value_uncached(
+                    indicator=dataset_id, date=year, iso=iso, frequency='M'
+                )
+            raise
 
 @meta(
     semanticConcept="CachedIMFQuery",


### PR DESCRIPTION
- Adds try/except fallback to monthly frequency in the \`ignore_cache=True\` branch of \`get_single_imf_datapoint()\`, matching the existing fallback in the cached branch
- Guards fallback so it only triggers when frequency is not already monthly
- Fixes \`__init____init__\` typo in \`Currency\` class constructor
- Adds missing \`datadesclib\` dependency to \`pyproject.toml\`

Closes #6

## Test plan
- [ ] Run \`pytest tests/\` and verify the \`ValueError\` for annual HICP data no longer occurs
- [ ] Verify fallback warnings are printed when annual data is unavailable
- [ ] Verify \`pip install .\` works with \`datadesclib\` now listed as a dependency"